### PR TITLE
Fix NV index attribute checks and secret size validation

### DIFF
--- a/cmd/api/types.go
+++ b/cmd/api/types.go
@@ -17,8 +17,10 @@ type PCRList struct {
 
 // RBP carries the rollback protection counter handle and expected value.
 type RBP struct {
-	Counter uint32 `json:"counter"`
-	Check   uint64 `json:"check"`
+	Counter  uint32 `json:"counter"`
+	Check    uint64 `json:"check"`
+	AuthMode int    `json:"authMode,omitempty"` // 0=owner, 1=index
+	Password []byte `json:"password,omitempty"`
 }
 
 // PolicySig holds the raw signature bytes from GenerateSignedPolicy.

--- a/cmd/api/types.go
+++ b/cmd/api/types.go
@@ -62,6 +62,7 @@ type NVCert struct {
 	Nonce      []byte `json:"nonce"`
 	AttestBlob []byte `json:"attestBlob"`
 	NVName     []byte `json:"nvName"`
+	SigHashAlg uint16 `json:"sigHashAlg"`
 	RSASig     []byte `json:"rsaSig,omitempty"`
 	ECCSigR    []byte `json:"eccSigR,omitempty"`
 	ECCSigS    []byte `json:"eccSigS,omitempty"`

--- a/cmd/api/types.go
+++ b/cmd/api/types.go
@@ -59,6 +59,7 @@ type NonceResp struct {
 type NVCert struct {
 	Nonce      []byte `json:"nonce"`
 	AttestBlob []byte `json:"attestBlob"`
+	NVName     []byte `json:"nvName"`
 	RSASig     []byte `json:"rsaSig,omitempty"`
 	ECCSigR    []byte `json:"eccSigR,omitempty"`
 	ECCSigS    []byte `json:"eccSigS,omitempty"`
@@ -81,4 +82,3 @@ type SignPolicyResp struct {
 	SignedPolicy SignedPolicy `json:"signedPolicy"`
 	NewRBP       RBP          `json:"newRbp"`
 }
-

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -311,6 +311,7 @@ func toAPINVCert(c tpmea.NVCertification) *api.NVCert {
 		Nonce:      c.Nonce,
 		AttestBlob: c.AttestBlob,
 		NVName:     c.NVName,
+		SigHashAlg: c.SigHashAlg,
 		RSASig:     c.RSASig,
 		ECCSigR:    c.ECCSigR,
 		ECCSigS:    c.ECCSigS,

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -309,6 +309,7 @@ func toAPINVCert(c tpmea.NVCertification) *api.NVCert {
 	return &api.NVCert{
 		Nonce:      c.Nonce,
 		AttestBlob: c.AttestBlob,
+		NVName:     c.NVName,
 		RSASig:     c.RSASig,
 		ECCSigR:    c.ECCSigR,
 		ECCSigS:    c.ECCSigS,

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -54,9 +54,10 @@ func main() {
 	log.Println("  Passed")
 
 	step("create rollback protection counter")
-	counterVal, err := tpmea.DefineMonotonicCounter(nvCounterIndex)
+	rbp := tpmea.RBP{Counter: nvCounterIndex}
+	counterVal, err := tpmea.DefineMonotonicCounter(rbp)
 	must(err, "define counter")
-	rbp := tpmea.RBP{Counter: nvCounterIndex, Check: counterVal}
+	rbp.Check = counterVal
 	log.Printf("  counter value: %d", counterVal)
 
 	step("read current PCR values")
@@ -79,7 +80,7 @@ func main() {
 	log.Println("  Passed")
 
 	step("increment counter to match the signed policy")
-	counterVal, err = tpmea.IncreaseMonotonicCounter(nvCounterIndex)
+	counterVal, err = tpmea.IncreaseMonotonicCounter(rbp)
 	must(err, "increment counter")
 	if counterVal != newRBP.Check {
 		log.Fatalf("counter after increment %d does not match policy check %d", counterVal, newRBP.Check)
@@ -94,7 +95,7 @@ func main() {
 
 	step("increment counter then request new policy - old policy must be rejected")
 	oldSP, oldRBP := sp, rbp
-	counterVal, err = tpmea.IncreaseMonotonicCounter(nvCounterIndex)
+	counterVal, err = tpmea.IncreaseMonotonicCounter(rbp)
 	must(err, "increment counter")
 	rbp.Check = counterVal
 	nonce, err = c.nonce()
@@ -103,7 +104,7 @@ func main() {
 	must(err, "certify counter")
 	sp, newRBP, err = c.signPolicy(pcrList, rbp, cert)
 	must(err, "sign next counter policy")
-	counterVal, err = tpmea.IncreaseMonotonicCounter(nvCounterIndex)
+	counterVal, err = tpmea.IncreaseMonotonicCounter(rbp)
 	must(err, "increment counter to policy check")
 	if counterVal != newRBP.Check {
 		log.Fatalf("counter after increment %d does not match policy check %d", counterVal, newRBP.Check)
@@ -154,7 +155,7 @@ func main() {
 	checkEqual(secret, readSecret, "re-unseal")
 
 	step("increment counter - old policy must be rejected")
-	counterVal, err = tpmea.IncreaseMonotonicCounter(nvCounterIndex)
+	counterVal, err = tpmea.IncreaseMonotonicCounter(rbp)
 	must(err, "increment counter")
 	_, err = tpmea.UnsealSecret(nvIndex, publicKey, sp, sel, rbp)
 	if err == nil {
@@ -170,7 +171,7 @@ func main() {
 	must(err, "certify counter")
 	sp, newRBP, err = c.signPolicy(pcrList, rbp, cert)
 	must(err, "sign updated policy")
-	counterVal, err = tpmea.IncreaseMonotonicCounter(nvCounterIndex)
+	counterVal, err = tpmea.IncreaseMonotonicCounter(rbp)
 	must(err, "increment counter to policy check")
 	if counterVal != newRBP.Check {
 		log.Fatalf("counter after increment %d does not match policy check %d", counterVal, newRBP.Check)
@@ -302,7 +303,7 @@ func toAPIPCRList(l tpmea.PCRList) api.PCRList {
 }
 
 func toAPIRBP(r tpmea.RBP) api.RBP {
-	return api.RBP{Counter: r.Counter, Check: r.Check}
+	return api.RBP{Counter: r.Counter, Check: r.Check, AuthMode: int(r.AuthMode), Password: r.Password}
 }
 
 func toAPINVCert(c tpmea.NVCertification) *api.NVCert {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -254,7 +254,7 @@ func fromAPIPCRList(a api.PCRList) tpmea.PCRList {
 }
 
 func fromAPIRBP(a api.RBP) tpmea.RBP {
-	return tpmea.RBP{Counter: a.Counter, Check: a.Check}
+	return tpmea.RBP{Counter: a.Counter, Check: a.Check, AuthMode: tpmea.CounterAuthMode(a.AuthMode), Password: a.Password}
 }
 
 func fromAPINVCert(a *api.NVCert) tpmea.NVCertification {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -262,6 +262,7 @@ func fromAPINVCert(a *api.NVCert) tpmea.NVCertification {
 		Nonce:      a.Nonce,
 		AttestBlob: a.AttestBlob,
 		NVName:     a.NVName,
+		SigHashAlg: a.SigHashAlg,
 		RSASig:     a.RSASig,
 		ECCSigR:    a.ECCSigR,
 		ECCSigS:    a.ECCSigS,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -35,6 +35,12 @@ type srv struct {
 
 	// latestNonce is the last freshness token issued via /api/nonce.
 	latestNonce []byte
+
+	// nvCounterName is the TPM Name of the client's NV counter index,
+	// cached from the first successful NV counter verification. Subsequent
+	// verifications check that the attested NV Name matches, preventing
+	// index-substitution attacks.
+	nvCounterName []byte
 }
 
 func main() {
@@ -165,6 +171,7 @@ func (s *srv) handleSignPolicy(w http.ResponseWriter, r *http.Request) {
 	priv := s.privateKey
 	aikPub := s.aikPub
 	issuedNonce := s.latestNonce
+	cachedNVName := s.nvCounterName
 	s.mu.RUnlock()
 
 	rbp := fromAPIRBP(req.RBP)
@@ -175,7 +182,7 @@ func (s *srv) handleSignPolicy(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		cert := fromAPINVCert(req.NVCert)
-		certified, err := tpmea.VerifyNVCounter(&cert, aikPub, issuedNonce)
+		certified, err := tpmea.VerifyNVCounter(&cert, aikPub, issuedNonce, cachedNVName)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("NV counter verification failed: %v", err), http.StatusUnauthorized)
 			return
@@ -183,6 +190,13 @@ func (s *srv) handleSignPolicy(w http.ResponseWriter, r *http.Request) {
 		if certified != req.RBP.Check {
 			http.Error(w, fmt.Sprintf("counter mismatch: certified=%d policy-check=%d", certified, req.RBP.Check), http.StatusUnauthorized)
 			return
+		}
+		// Cache the NV Name from the first successful verification so
+		// subsequent requests are bound to the same NV index.
+		if len(cachedNVName) == 0 && len(cert.NVName) > 0 {
+			s.mu.Lock()
+			s.nvCounterName = cert.NVName
+			s.mu.Unlock()
 		}
 		log.Printf("NV counter certified: value=%d", certified)
 		// Sign the next counter value - client must increment before unsealing.
@@ -247,6 +261,7 @@ func fromAPINVCert(a *api.NVCert) tpmea.NVCertification {
 	return tpmea.NVCertification{
 		Nonce:      a.Nonce,
 		AttestBlob: a.AttestBlob,
+		NVName:     a.NVName,
 		RSASig:     a.RSASig,
 		ECCSigR:    a.ECCSigR,
 		ECCSigS:    a.ECCSigS,

--- a/tpmea.go
+++ b/tpmea.go
@@ -588,6 +588,142 @@ func UnsealSecret(handle uint32, publicKey crypto.PublicKey, sp SignedPolicy, se
 	return tpm.NVRead(index, index, pub.Size, 0, polss)
 }
 
+// aes128CFBSymDef returns the SymDef for AES-128-CFB, the standard symmetric
+// algorithm for TPM session-based parameter encryption.
+func aes128CFBSymDef() *tpm2.SymDef {
+	return &tpm2.SymDef{
+		Algorithm: tpm2.SymAlgorithmAES,
+		KeyBits:   &tpm2.SymKeyBitsU{Sym: 128},
+		Mode:      &tpm2.SymModeU{Sym: tpm2.SymModeCFB},
+	}
+}
+
+// startSaltedHMACSession creates a salted HMAC session with AES-128-CFB as the
+// symmetric algorithm for parameter encryption. saltKeyHandle is the handle of
+// an asymmetric decrypt key whose public part is used to encrypt the salt value.
+func startSaltedHMACSession(tpm *tpm2.TPMContext, saltKeyHandle uint32) (tpm2.SessionContext, error) {
+	saltKey, err := tpm.NewResourceContext(tpm2.Handle(saltKeyHandle))
+	if err != nil {
+		return nil, fmt.Errorf("cannot load salt key at 0x%08x: %w", saltKeyHandle, err)
+	}
+	return tpm.StartAuthSession(saltKey, nil, tpm2.SessionTypeHMAC, aes128CFBSymDef(), tpm2.HashAlgorithmSHA256)
+}
+
+// SealSecretEncrypted writes the secret to the TPM like SealSecret, but uses a
+// salted HMAC session with AES-128-CFB parameter encryption to protect the
+// secret on the CPU-TPM bus. saltKeyHandle is the handle of a loaded asymmetric
+// decrypt key (e.g. EK) used to establish the encrypted session.
+func SealSecretEncrypted(handle uint32, authDigest []byte, secret []byte, saltKeyHandle uint32) error {
+	if authDigest == nil || secret == nil {
+		return fmt.Errorf("invalid parameter(s)")
+	}
+	if len(authDigest) == 0 {
+		return fmt.Errorf("authDigest must not be empty: an empty policy allows unauthorized access")
+	}
+	if len(secret) == 0 {
+		return fmt.Errorf("secret must not be empty")
+	}
+
+	tpm, err := getTpmHandle()
+	if err != nil {
+		return err
+	}
+	defer tpm.Close()
+
+	nvBufMax, err := tpm.GetNVBufferMax()
+	if err != nil {
+		return fmt.Errorf("failed to query TPM_PT_NV_BUFFER_MAX: %w", err)
+	}
+	if len(secret) > nvBufMax {
+		return fmt.Errorf("secret too large: %d bytes exceeds TPM NV buffer max of %d", len(secret), nvBufMax)
+	}
+
+	// if the handle already exists, verify it is an ordinary NV index before
+	// overwriting it.
+	index, err := tpm.NewResourceContext(tpm2.Handle(handle))
+	if err == nil {
+		nvpub, _, err := tpm.NVReadPublic(index)
+		if err != nil {
+			return err
+		}
+		if nvpub.Attrs.Type() != tpm2.NVTypeOrdinary {
+			return fmt.Errorf("NV index 0x%x exists but is not an ordinary NV index (type: %v)", handle, nvpub.Attrs.Type())
+		}
+		err = tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	nvpub := tpm2.NVPublic{
+		Index:      tpm2.Handle(handle),
+		NameAlg:    tpm2.HashAlgorithmSHA256,
+		Attrs:      tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVPolicyRead | tpm2.AttrNVOwnerWrite | tpm2.AttrNVReadStClear),
+		AuthPolicy: authDigest,
+		Size:       uint16(len(secret))}
+	index, err = tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &nvpub, nil)
+	if err != nil {
+		return err
+	}
+
+	// create a salted HMAC session with AES-128-CFB; the CommandEncrypt
+	// attribute tells the TPM to decrypt the first command parameter (the
+	// secret data) so it travels encrypted on the bus.
+	hmacSess, err := startSaltedHMACSession(tpm, saltKeyHandle)
+	if err != nil {
+		return fmt.Errorf("creating encrypted session: %w", err)
+	}
+	defer tpm.FlushContext(hmacSess)
+
+	encSess := hmacSess.WithAttrs(tpm2.AttrCommandEncrypt)
+	return tpm.NVWrite(tpm.OwnerHandleContext(), index, secret, 0, nil, encSess)
+}
+
+// UnsealSecretEncrypted reads the secret from the TPM like UnsealSecret, but
+// uses a salted HMAC session with AES-128-CFB parameter encryption to protect
+// the returned secret on the CPU-TPM bus. saltKeyHandle is the handle of a
+// loaded asymmetric decrypt key (e.g. EK) used to establish the encrypted
+// session.
+func UnsealSecretEncrypted(handle uint32, publicKey crypto.PublicKey, sp SignedPolicy, sel PCRSelection, rbp RBP, saltKeyHandle uint32) ([]byte, error) {
+	if publicKey == nil || sp.Sig == nil || sp.Digest == nil {
+		return nil, fmt.Errorf("invalid parameter(s)")
+	}
+
+	tpm, err := getTpmHandle()
+	if err != nil {
+		return nil, err
+	}
+	defer tpm.Close()
+
+	index, err := tpm.NewResourceContext(tpm2.Handle(handle))
+	if err != nil {
+		return nil, err
+	}
+
+	polss, err := authorizeObject(tpm, publicKey, sp, sel, rbp)
+	if err != nil {
+		return nil, err
+	}
+	defer tpm.FlushContext(polss)
+
+	pub, _, err := tpm.NVReadPublic(index)
+	if err != nil {
+		return nil, err
+	}
+
+	// create a salted HMAC session with AES-128-CFB; the ResponseEncrypt
+	// attribute tells the TPM to encrypt the first response parameter (the
+	// secret data) so it travels encrypted on the bus.
+	hmacSess, err := startSaltedHMACSession(tpm, saltKeyHandle)
+	if err != nil {
+		return nil, fmt.Errorf("creating encrypted session: %w", err)
+	}
+	defer tpm.FlushContext(hmacSess)
+
+	encSess := hmacSess.WithAttrs(tpm2.AttrResponseEncrypt)
+	return tpm.NVRead(index, index, pub.Size, 0, polss, encSess)
+}
+
 // ActivateReadLock prevents further reading of the data from provided index,
 // this restriction will gets deactivated on next tpm reset or restart.
 func ActivateReadLock(handle uint32, publicKey crypto.PublicKey, sp SignedPolicy, sel PCRSelection, rbp RBP) error {

--- a/tpmea.go
+++ b/tpmea.go
@@ -41,6 +41,10 @@ type NVCertification struct {
 	// AttestBlob is the raw marshaled TPMS_ATTEST structure. The signing
 	// key's signature covers SHA-256(AttestBlob).
 	AttestBlob []byte
+	// NVName is the TPM Name of the certified NV index, extracted from the
+	// attestation. Verifiers should compare it against an expected value to
+	// ensure the certification refers to the correct NV index.
+	NVName []byte
 	// RSASig is set when the signing key is RSA (PKCS#1v15).
 	RSASig []byte
 	// ECCSigR and ECCSigS are set when the signing key is ECDSA.
@@ -785,6 +789,28 @@ func ReadNVAuthDigest(handle uint32) ([]byte, error) {
 	return info.AuthPolicy, nil
 }
 
+// ReadNVName returns the TPM Name of the NV index at handle. The Name is a
+// cryptographic identifier derived from the full NV public area.
+func ReadNVName(handle uint32) ([]byte, error) {
+	tpm, err := getTpmHandle()
+	if err != nil {
+		return nil, err
+	}
+	defer tpm.Close()
+
+	index, err := tpm.NewResourceContext(tpm2.Handle(handle))
+	if err != nil {
+		return nil, err
+	}
+
+	_, name, err := tpm.NVReadPublic(index)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(name), nil
+}
+
 // CertifyNVCounter runs TPM2_NV_Certify on the NV counter at nvHandle, signed
 // by the key at akHandle. nonce is a freshness token from the verifier; the
 // TPM embeds it in the attestation so replays can be detected.
@@ -812,7 +838,11 @@ func CertifyNVCounter(akHandle, nvHandle uint32, nonce []byte) (NVCertification,
 		return NVCertification{}, fmt.Errorf("marshal attest: %w", err)
 	}
 
-	cert := NVCertification{Nonce: nonce, AttestBlob: attestBytes}
+	cert := NVCertification{
+		Nonce:      nonce,
+		AttestBlob: attestBytes,
+		NVName:     []byte(attest.Attested.NV.IndexName),
+	}
 	switch sig.SigAlg {
 	case tpm2.SigSchemeAlgRSASSA:
 		cert.RSASig = []byte(sig.Signature.RSASSA.Sig)
@@ -827,10 +857,13 @@ func CertifyNVCounter(akHandle, nvHandle uint32, nonce []byte) (NVCertification,
 
 // VerifyNVCounter verifies that cert was produced by the TPM holding the key
 // whose public component is akPub and that the attestation is bound to nonce
-// (replay protection). It returns the certified counter value on success.
-func VerifyNVCounter(cert *NVCertification, akPub crypto.PublicKey, nonce []byte) (uint64, error) {
+// (replay protection). expectedNVName is the TPM Name of the NV index that
+// should appear in the attestation; if non-empty the function rejects
+// certifications for any other NV index, preventing index-substitution attacks.
+// It returns the certified counter value on success.
+func VerifyNVCounter(cert *NVCertification, akPub crypto.PublicKey, nonce []byte, expectedNVName []byte) (uint64, error) {
 	if cert == nil {
-		return 0, nil
+		return 0, fmt.Errorf("certification not provided")
 	}
 
 	digest := sha256.Sum256(cert.AttestBlob)
@@ -873,6 +906,14 @@ func VerifyNVCounter(cert *NVCertification, akPub crypto.PublicKey, nonce []byte
 	nvInfo := attest.Attested.NV
 	if nvInfo == nil {
 		return 0, errors.New("attestation missing NV certify info")
+	}
+	if len(expectedNVName) > 0 && !bytes.Equal([]byte(nvInfo.IndexName), expectedNVName) {
+		return 0, fmt.Errorf("NV index name mismatch: certified index has name %x, expected %x",
+			[]byte(nvInfo.IndexName), expectedNVName)
+	}
+	// verify the offset is strictly 0
+	if nvInfo.Offset != 0 {
+		return 0, fmt.Errorf("unexpected NV offset %d, want 0", nvInfo.Offset)
 	}
 	if len(nvInfo.NVContents) != 8 {
 		return 0, fmt.Errorf("unexpected NV contents length %d, want 8", len(nvInfo.NVContents))

--- a/tpmea.go
+++ b/tpmea.go
@@ -654,7 +654,17 @@ func GenerateSignedPolicy(privateKey crypto.PrivateKey, pcrList PCRList, rbp RBP
 			return SignedPolicy{}, err
 		}
 
-		// PolicyNV : index value <= operandB
+		// PolicyNV : index value <= operandB (check value)
+		// This is source of confusion, the reason for less than or equal
+		// operator is to allow legitiate rollback has chance of sucess
+		// (i.e. update failiure), but when a new policy is applied sucessfully,
+		// device is expected to increase the counter value to match the check
+		// value, making older policy with smaller check value no longer valid.
+		// example:
+		//.  Old policy : check value = 5, device counter value = 5, 5 <= 5 policy holds.
+		//.  New policy : check value = 6, device counter value = 5, 5 <= 6 policy holds.
+		//   Device applies new policy, increases counter value to 6.
+		//  Old policy : check value = 5, device counter value = 6, 6 !<= 5policy no longer holds.
 		operandB := make([]byte, 8)
 		binary.BigEndian.PutUint64(operandB, rbp.Check)
 		err = tpm.PolicyNV(tpm.OwnerHandleContext(), index, triss, operandB, 0, tpm2.OpUnsignedLE, nil)

--- a/tpmea.go
+++ b/tpmea.go
@@ -324,9 +324,13 @@ func defineMonotonicCounterOn(tpm *tpm2.TPMContext, handle uint32) (uint64, erro
 			return 0, err
 		}
 
-		// check if the type and attributes match what we need, if so, just use the handle.
-		attr := tpm2.AttrNVOwnerRead | tpm2.AttrNVOwnerWrite
-		if nvpub.Attrs.Type() != tpm2.NVTypeCounter || (nvpub.Attrs&attr) != attr {
+		// Strict equality check against the canonical attributes (minus
+		// AttrNVWritten bit, it set at runtime and checked next). Since
+		// the NV Name is a hash of the full public area, any extra bit
+		// would cause a policy digest mismatch between the policy creator
+		// and policy consumer.
+		expectedAttrs := tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVOwnerRead | tpm2.AttrNVOwnerWrite)
+		if nvpub.Attrs&^tpm2.AttrNVWritten != expectedAttrs {
 			return 0, errors.New("a counter at provide handle already exists with mismatched attributes")
 		}
 

--- a/tpmea.go
+++ b/tpmea.go
@@ -923,11 +923,7 @@ func VerifyNVCounter(cert *NVCertification, akPub crypto.PublicKey, nonce []byte
 }
 
 // nvCertify executes TPM2_NV_Certify.
-func nvCertify(
-	tpm *tpm2.TPMContext,
-	signCtx, authCtx, nvCtx tpm2.ResourceContext,
-	nonce []byte,
-) (*tpm2.Attest, *tpm2.Signature, error) {
+func nvCertify(tpm *tpm2.TPMContext, signCtx, authCtx, nvCtx tpm2.ResourceContext, nonce []byte) (*tpm2.Attest, *tpm2.Signature, error) {
 	inScheme := &tpm2.SigScheme{Scheme: tpm2.SigSchemeAlgNull}
 	var attest *tpm2.Attest
 	var sig *tpm2.Signature
@@ -937,7 +933,7 @@ func nvCertify(
 			tpm2.UseResourceContextWithAuth(authCtx, nil),
 			tpm2.UseHandleContext(nvCtx),
 		).
-		AddParams(tpm2.Data(nonce), inScheme, uint16(8), uint16(0)).
+		AddParams(tpm2.Data(nonce), inScheme, uint16(8), uint16(0)). // offset is 0, size is 8 for monotonic counter
 		Run(nil, mu.Sized(&attest), &sig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("TPM2_NV_Certify: %w", err)

--- a/tpmea.go
+++ b/tpmea.go
@@ -85,9 +85,51 @@ type PCRList struct {
 	Algo PCRHashAlgo
 }
 
+type CounterAuthMode int
+
+const (
+	// CounterAuthOwner uses the TPM Owner hierarchy to authorize counter
+	// operations. The counter is defined with AttrNVOwnerRead|AttrNVOwnerWrite.
+	// This requires the  caller to know the owner password
+	// (empty by default on fresh TPMs).
+	CounterAuthOwner = CounterAuthMode(0)
+
+	// CounterAuthIndex uses the NV index's own auth value (password) to
+	// authorize counter operations. The counter is defined with
+	// AttrNVAuthRead|AttrNVAuthWrite and all access goes through the index
+	// handle with the provided password. This decouples the counter from the
+	// Owner hierarchy, making it usable in environments where the owner
+	// password is unknown.
+	CounterAuthIndex = CounterAuthMode(1)
+)
+
 type RBP struct {
-	Counter uint32
-	Check   uint64
+	Counter  uint32
+	Check    uint64
+	AuthMode CounterAuthMode
+	Password []byte
+}
+
+// hasCounter reports whether this RBP carries a rollback protection counter.
+func (r RBP) hasCounter() bool { return r.Counter != 0 }
+
+// counterNVAttrs returns the NV attributes appropriate for this auth mode.
+func (r RBP) counterNVAttrs() tpm2.NVAttributes {
+	if r.AuthMode == CounterAuthIndex {
+		return tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVAuthRead | tpm2.AttrNVAuthWrite)
+	}
+	return tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVOwnerRead | tpm2.AttrNVOwnerWrite)
+}
+
+// counterAuthCtx returns the authorization context to use for counter
+// operations. For Owner mode this is the owner handle; for Index mode
+// it is the NV index itself with the password set as auth value.
+func (r RBP) counterAuthCtx(tpm *tpm2.TPMContext, index tpm2.ResourceContext) tpm2.ResourceContext {
+	if r.AuthMode == CounterAuthIndex {
+		index.SetAuthValue(r.Password)
+		return index
+	}
+	return tpm.OwnerHandleContext()
 }
 
 func getPCRAlgo(algo PCRHashAlgo) (tpm2.HashAlgorithmId, error) {
@@ -280,17 +322,19 @@ func authorizeObject(tpm *tpm2.TPMContext, publicKey crypto.PublicKey, sp Signed
 		}
 	}()
 
-	if rbp != (RBP{}) {
+	if rbp.hasCounter() {
 		index, err := tpm.NewResourceContext(tpm2.Handle(rbp.Counter))
 		if err != nil {
 			return nil, err
 		}
 
+		authCtx := rbp.counterAuthCtx(tpm, index)
+
 		// if rbp is provided, first check the PolicyNV then PolicyPCR, in this
 		// case the two policies form a logical AND (PolicyNV AND PolicyPCR).
 		operandB := make([]byte, 8)
 		binary.BigEndian.PutUint64(operandB, rbp.Check)
-		err = tpm.PolicyNV(tpm.OwnerHandleContext(), index, polss, operandB, 0, tpm2.OpUnsignedLE, nil)
+		err = tpm.PolicyNV(authCtx, index, polss, operandB, 0, tpm2.OpUnsignedLE, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -319,7 +363,10 @@ func authorizeObject(tpm *tpm2.TPMContext, publicKey crypto.PublicKey, sp Signed
 
 // defineMonotonicCounterOn ensures the NV counter at handle exists and is
 // initialized on the given tpm connection, returning its current value.
-func defineMonotonicCounterOn(tpm *tpm2.TPMContext, handle uint32) (uint64, error) {
+func defineMonotonicCounterOn(tpm *tpm2.TPMContext, rbp RBP) (uint64, error) {
+	handle := rbp.Counter
+	expectedAttrs := rbp.counterNVAttrs()
+
 	index, err := tpm.NewResourceContext(tpm2.Handle(handle))
 	if err == nil {
 		// handle already exists, read its attributes.
@@ -333,20 +380,21 @@ func defineMonotonicCounterOn(tpm *tpm2.TPMContext, handle uint32) (uint64, erro
 		// the NV Name is a hash of the full public area, any extra bit
 		// would cause a policy digest mismatch between the policy creator
 		// and policy consumer.
-		expectedAttrs := tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVOwnerRead | tpm2.AttrNVOwnerWrite)
 		if nvpub.Attrs&^tpm2.AttrNVWritten != expectedAttrs {
 			return 0, errors.New("a counter at provide handle already exists with mismatched attributes")
 		}
 
+		authCtx := rbp.counterAuthCtx(tpm, index)
+
 		// if it's not initialized, initialize it by increasing it.
 		if (nvpub.Attrs & tpm2.AttrNVWritten) != tpm2.AttrNVWritten {
-			err = tpm.NVIncrement(tpm.OwnerHandleContext(), index, nil)
+			err = tpm.NVIncrement(authCtx, index, nil)
 			if err != nil {
 				return 0, err
 			}
 		}
 
-		counter, err := tpm.NVReadCounter(tpm.OwnerHandleContext(), index, nil)
+		counter, err := tpm.NVReadCounter(authCtx, index, nil)
 		if err != nil {
 			return 0, err
 		}
@@ -358,49 +406,57 @@ func defineMonotonicCounterOn(tpm *tpm2.TPMContext, handle uint32) (uint64, erro
 	nvpub := tpm2.NVPublic{
 		Index:   tpm2.Handle(handle),
 		NameAlg: tpm2.HashAlgorithmSHA256,
-		Attrs:   tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVOwnerRead | tpm2.AttrNVOwnerWrite),
+		Attrs:   expectedAttrs,
 		Size:    8}
-	index, err = tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &nvpub, nil)
+	// NVDefineSpace always requires owner or platform auth.
+	index, err = tpm.NVDefineSpace(tpm.OwnerHandleContext(), rbp.Password, &nvpub, nil)
 	if err != nil {
 		return 0, err
 	}
+
+	authCtx := rbp.counterAuthCtx(tpm, index)
 
 	// increasing the counter is necessary to initialize it.
-	err = tpm.NVIncrement(tpm.OwnerHandleContext(), index, nil)
+	err = tpm.NVIncrement(authCtx, index, nil)
 	if err != nil {
 		return 0, err
 	}
 
-	return tpm.NVReadCounter(tpm.OwnerHandleContext(), index, nil)
+	return tpm.NVReadCounter(authCtx, index, nil)
 }
 
 // DefineMonotonicCounter will define a monotonic NV counter at the given index,
 // function will initialize the counter and returns its current value.
 //
-// monotonic counters will retain their value and won't go away even if undefined,
+// The rbp.AuthMode field controls the authorization model:
+//   - CounterAuthOwner (default): uses Owner hierarchy (AttrNVOwnerRead/Write).
+//   - CounterAuthIndex: uses the NV index's own auth value (AttrNVAuthRead/Write).
+//     rbp.Password is set as the auth value for the index.
+//
+// Monotonic counters will retain their value and won't go away even if undefined,
 // because of this if the handle already exist and it's attributes matches what
 // we need, it will get initialized first if it is uninitialized, and then
 // its current value is returned.
-func DefineMonotonicCounter(handle uint32) (uint64, error) {
+func DefineMonotonicCounter(rbp RBP) (uint64, error) {
 	tpm, err := getTpmHandle()
 	if err != nil {
 		return 0, err
 	}
 	defer tpm.Close()
 
-	return defineMonotonicCounterOn(tpm, handle)
+	return defineMonotonicCounterOn(tpm, rbp)
 }
 
 // IncreaseMonotonicCounter will increase the value of the monotonic counter at
 // provided index, by one and returns the new value.
-func IncreaseMonotonicCounter(handle uint32) (uint64, error) {
+func IncreaseMonotonicCounter(rbp RBP) (uint64, error) {
 	tpm, err := getTpmHandle()
 	if err != nil {
 		return 0, err
 	}
 	defer tpm.Close()
 
-	index, err := tpm.NewResourceContext(tpm2.Handle(handle))
+	index, err := tpm.NewResourceContext(tpm2.Handle(rbp.Counter))
 	if err != nil {
 		return 0, err
 	}
@@ -410,15 +466,17 @@ func IncreaseMonotonicCounter(handle uint32) (uint64, error) {
 		return 0, err
 	}
 	if nvpub.Attrs.Type() != tpm2.NVTypeCounter {
-		return 0, fmt.Errorf("NV index 0x%x is not a monotonic counter", handle)
+		return 0, fmt.Errorf("NV index 0x%x is not a monotonic counter", rbp.Counter)
 	}
 
-	err = tpm.NVIncrement(tpm.OwnerHandleContext(), index, nil)
+	authCtx := rbp.counterAuthCtx(tpm, index)
+
+	err = tpm.NVIncrement(authCtx, index, nil)
 	if err != nil {
 		return 0, err
 	}
 
-	counter, err := tpm.NVReadCounter(tpm.OwnerHandleContext(), index, nil)
+	counter, err := tpm.NVReadCounter(authCtx, index, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -645,11 +703,11 @@ func GenerateSignedPolicy(privateKey crypto.PrivateKey, pcrList PCRList, rbp RBP
 	}
 	defer tpm.FlushContext(triss)
 
-	if rbp != (RBP{}) {
+	if rbp.hasCounter() {
 		// The trial session needs the NV index to exist on this TPM so it can
 		// compute the correct policy name. Create it on the same connection if
 		// it is not already present; value does not matter for name derivation.
-		if _, err := defineMonotonicCounterOn(tpm, rbp.Counter); err != nil {
+		if _, err := defineMonotonicCounterOn(tpm, rbp); err != nil {
 			return SignedPolicy{}, err
 		}
 
@@ -657,6 +715,8 @@ func GenerateSignedPolicy(privateKey crypto.PrivateKey, pcrList PCRList, rbp RBP
 		if err != nil {
 			return SignedPolicy{}, err
 		}
+
+		authCtx := rbp.counterAuthCtx(tpm, index)
 
 		// PolicyNV : index value <= operandB (check value)
 		// This is source of confusion, the reason for less than or equal
@@ -671,7 +731,7 @@ func GenerateSignedPolicy(privateKey crypto.PrivateKey, pcrList PCRList, rbp RBP
 		//  Old policy : check value = 5, device counter value = 6, 6 !<= 5policy no longer holds.
 		operandB := make([]byte, 8)
 		binary.BigEndian.PutUint64(operandB, rbp.Check)
-		err = tpm.PolicyNV(tpm.OwnerHandleContext(), index, triss, operandB, 0, tpm2.OpUnsignedLE, nil)
+		err = tpm.PolicyNV(authCtx, index, triss, operandB, 0, tpm2.OpUnsignedLE, nil)
 		if err != nil {
 			return SignedPolicy{}, err
 		}

--- a/tpmea.go
+++ b/tpmea.go
@@ -9,7 +9,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
-	"crypto/sha256"
+	_ "crypto/sha256"
+	_ "crypto/sha512"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -39,12 +40,16 @@ type NVCertification struct {
 	// embeds it in the signed blob so the verifier can confirm freshness.
 	Nonce []byte
 	// AttestBlob is the raw marshaled TPMS_ATTEST structure. The signing
-	// key's signature covers SHA-256(AttestBlob).
+	// key's signature covers hash(AttestBlob) using the algorithm in SigHashAlg.
 	AttestBlob []byte
 	// NVName is the TPM Name of the certified NV index, extracted from the
 	// attestation. Verifiers should compare it against an expected value to
 	// ensure the certification refers to the correct NV index.
 	NVName []byte
+	// SigHashAlg is the TPM hash algorithm ID (e.g. tpm2.HashAlgorithmSHA256)
+	// used to digest AttestBlob before signing. It is recorded so that
+	// VerifyNVCounter can use the correct hash without hardcoding SHA-256.
+	SigHashAlg uint16
 	// RSASig is set when the signing key is RSA (PKCS#1v15).
 	RSASig []byte
 	// ECCSigR and ECCSigS are set when the signing key is ECDSA.
@@ -902,6 +907,7 @@ func CertifyNVCounter(akHandle, nvHandle uint32, nonce []byte) (NVCertification,
 		Nonce:      nonce,
 		AttestBlob: attestBytes,
 		NVName:     []byte(attest.Attested.NV.IndexName),
+		SigHashAlg: uint16(sig.HashAlg()),
 	}
 	switch sig.SigAlg {
 	case tpm2.SigSchemeAlgRSASSA:
@@ -926,14 +932,21 @@ func VerifyNVCounter(cert *NVCertification, akPub crypto.PublicKey, nonce []byte
 		return 0, fmt.Errorf("certification not provided")
 	}
 
-	digest := sha256.Sum256(cert.AttestBlob)
+	hashAlg := tpm2.HashAlgorithmId(cert.SigHashAlg)
+	goHash := hashAlg.GetHash()
+	if !goHash.Available() {
+		return 0, fmt.Errorf("unsupported or unavailable hash algorithm 0x%04x", cert.SigHashAlg)
+	}
+	h := goHash.New()
+	h.Write(cert.AttestBlob)
+	digest := h.Sum(nil)
 
 	switch pub := akPub.(type) {
 	case *rsa.PublicKey:
 		if len(cert.RSASig) == 0 {
 			return 0, errors.New("RSA key but no RSA signature in certification")
 		}
-		if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, digest[:], cert.RSASig); err != nil {
+		if err := rsa.VerifyPKCS1v15(pub, goHash, digest, cert.RSASig); err != nil {
 			return 0, fmt.Errorf("signature verification failed: %w", err)
 		}
 	case *ecdsa.PublicKey:
@@ -942,7 +955,7 @@ func VerifyNVCounter(cert *NVCertification, akPub crypto.PublicKey, nonce []byte
 		}
 		r := new(big.Int).SetBytes(cert.ECCSigR)
 		s := new(big.Int).SetBytes(cert.ECCSigS)
-		if !ecdsa.Verify(pub, digest[:], r, s) {
+		if !ecdsa.Verify(pub, digest, r, s) {
 			return 0, errors.New("ECDSA signature verification failed")
 		}
 	default:

--- a/tpmea.go
+++ b/tpmea.go
@@ -13,7 +13,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 
 	"github.com/canonical/go-tpm2"
@@ -434,15 +433,19 @@ func SealSecret(handle uint32, authDigest []byte, secret []byte) error {
 		return fmt.Errorf("secret must not be empty")
 	}
 
-	if len(secret) > math.MaxUint16 {
-		return fmt.Errorf("secret too large: %d bytes exceeds TPM NV max of %d", len(secret), math.MaxUint16)
-	}
-
 	tpm, err := getTpmHandle()
 	if err != nil {
 		return err
 	}
 	defer tpm.Close()
+
+	nvBufMax, err := tpm.GetNVBufferMax()
+	if err != nil {
+		return fmt.Errorf("failed to query TPM_PT_NV_BUFFER_MAX: %w", err)
+	}
+	if len(secret) > nvBufMax {
+		return fmt.Errorf("secret too large: %d bytes exceeds TPM NV buffer max of %d", len(secret), nvBufMax)
+	}
 
 	// if the handle already exists, verify it is an ordinary NV index before
 	// overwriting it.

--- a/tpmea_test.go
+++ b/tpmea_test.go
@@ -838,6 +838,11 @@ func TestCertifyNVCounter(t *testing.T) {
 		t.Fatalf("DefineMonotonicCounter: %v", err)
 	}
 
+	nvName, err := ReadNVName(NV_COUNTER_INDEX)
+	if err != nil {
+		t.Fatalf("ReadNVName: %v", err)
+	}
+
 	nonce := make([]byte, 32)
 	if _, err := crand.Read(nonce); err != nil {
 		t.Fatalf("generate nonce: %v", err)
@@ -848,7 +853,7 @@ func TestCertifyNVCounter(t *testing.T) {
 		t.Fatalf("CertifyNVCounter: %v", err)
 	}
 
-	certified, err := VerifyNVCounter(&cert, aikPub, nonce)
+	certified, err := VerifyNVCounter(&cert, aikPub, nonce, nvName)
 	if err != nil {
 		t.Fatalf("VerifyNVCounter: %v", err)
 	}
@@ -873,6 +878,11 @@ func TestVerifyNVCounterIncrementedValue(t *testing.T) {
 		t.Fatalf("IncreaseMonotonicCounter: %v", err)
 	}
 
+	nvName, err := ReadNVName(NV_COUNTER_INDEX)
+	if err != nil {
+		t.Fatalf("ReadNVName: %v", err)
+	}
+
 	nonce := make([]byte, 32)
 	if _, err := crand.Read(nonce); err != nil {
 		t.Fatalf("generate nonce: %v", err)
@@ -883,7 +893,7 @@ func TestVerifyNVCounterIncrementedValue(t *testing.T) {
 		t.Fatalf("CertifyNVCounter: %v", err)
 	}
 
-	certified, err := VerifyNVCounter(&cert, aikPub, nonce)
+	certified, err := VerifyNVCounter(&cert, aikPub, nonce, nvName)
 	if err != nil {
 		t.Fatalf("VerifyNVCounter: %v", err)
 	}
@@ -917,7 +927,7 @@ func TestVerifyNVCounterNonceMismatch(t *testing.T) {
 		t.Fatalf("generate different nonce: %v", err)
 	}
 
-	_, err = VerifyNVCounter(&cert, aikPub, differentNonce)
+	_, err = VerifyNVCounter(&cert, aikPub, differentNonce, cert.NVName)
 	if err == nil {
 		t.Fatal("expected nonce mismatch error, got nil")
 	}
@@ -942,7 +952,7 @@ func TestVerifyNVCounterWrongKey(t *testing.T) {
 	}
 
 	wrongKey, _ := genTpmKeyPairRSA()
-	_, err = VerifyNVCounter(&cert, &wrongKey.PublicKey, nonce)
+	_, err = VerifyNVCounter(&cert, &wrongKey.PublicKey, nonce, cert.NVName)
 	if err == nil {
 		t.Fatal("expected signature verification error with wrong key, got nil")
 	}
@@ -970,22 +980,18 @@ func TestVerifyNVCounterTamperedSignature(t *testing.T) {
 
 	cert.RSASig[0] ^= 0xff
 
-	_, err = VerifyNVCounter(&cert, aikPub, nonce)
+	_, err = VerifyNVCounter(&cert, aikPub, nonce, cert.NVName)
 	if err == nil {
 		t.Fatal("expected signature verification error after tampering, got nil")
 	}
 }
 
-// TestVerifyNVCounterNilCert verifies that a nil cert skips all checks and
-// returns (0, nil) without any TPM interaction.
+// TestVerifyNVCounterNilCert verifies that a nil cert returns an error.
 func TestVerifyNVCounterNilCert(t *testing.T) {
 	key, _ := genTpmKeyPairRSA()
-	val, err := VerifyNVCounter(nil, &key.PublicKey, []byte("nonce"))
-	if err != nil {
-		t.Fatalf("expected nil error for nil cert, got %v", err)
-	}
-	if val != 0 {
-		t.Fatalf("expected 0 for nil cert, got %d", val)
+	_, err := VerifyNVCounter(nil, &key.PublicKey, []byte("nonce"), nil)
+	if err == nil {
+		t.Fatal("expected error for nil cert, got nil")
 	}
 }
 
@@ -993,7 +999,7 @@ func TestVerifyNVCounterNilCert(t *testing.T) {
 // RSA or ECDSA returns an error immediately.
 func TestVerifyNVCounterUnsupportedKeyType(t *testing.T) {
 	cert := NVCertification{AttestBlob: []byte("dummy")}
-	_, err := VerifyNVCounter(&cert, "not-a-real-key", []byte("nonce"))
+	_, err := VerifyNVCounter(&cert, "not-a-real-key", []byte("nonce"), nil)
 	if err == nil {
 		t.Fatal("expected error for unsupported key type, got nil")
 	}
@@ -1004,7 +1010,7 @@ func TestVerifyNVCounterUnsupportedKeyType(t *testing.T) {
 func TestVerifyNVCounterRSAMissingSignature(t *testing.T) {
 	key, _ := genTpmKeyPairRSA()
 	cert := NVCertification{AttestBlob: []byte("dummy")} // RSASig intentionally empty
-	_, err := VerifyNVCounter(&cert, &key.PublicKey, []byte("nonce"))
+	_, err := VerifyNVCounter(&cert, &key.PublicKey, []byte("nonce"), nil)
 	if err == nil {
 		t.Fatal("expected error for missing RSA signature, got nil")
 	}
@@ -1020,7 +1026,7 @@ func TestVerifyNVCounterECCMissingComponents(t *testing.T) {
 		ECCSigR:    []byte{0x01},
 		// ECCSigS intentionally absent
 	}
-	_, err := VerifyNVCounter(&certMissingS, &key.PublicKey, []byte("nonce"))
+	_, err := VerifyNVCounter(&certMissingS, &key.PublicKey, []byte("nonce"), nil)
 	if err == nil {
 		t.Fatal("expected error for missing ECDSA S component, got nil")
 	}
@@ -1030,8 +1036,35 @@ func TestVerifyNVCounterECCMissingComponents(t *testing.T) {
 		// ECCSigR intentionally absent
 		ECCSigS: []byte{0x01},
 	}
-	_, err = VerifyNVCounter(&certMissingR, &key.PublicKey, []byte("nonce"))
+	_, err = VerifyNVCounter(&certMissingR, &key.PublicKey, []byte("nonce"), nil)
 	if err == nil {
 		t.Fatal("expected error for missing ECDSA R component, got nil")
+	}
+}
+
+// TestVerifyNVCounterWrongNVName verifies that presenting a valid
+// certification but with a mismatched expected NV Name is rejected.
+func TestVerifyNVCounterWrongNVName(t *testing.T) {
+	aikPub := readAIKPublicKey(t)
+
+	_, err := DefineMonotonicCounter(NV_COUNTER_INDEX)
+	if err != nil {
+		t.Fatalf("DefineMonotonicCounter: %v", err)
+	}
+
+	nonce := make([]byte, 32)
+	if _, err := crand.Read(nonce); err != nil {
+		t.Fatalf("generate nonce: %v", err)
+	}
+
+	cert, err := CertifyNVCounter(AIK_HANDLE, NV_COUNTER_INDEX, nonce)
+	if err != nil {
+		t.Fatalf("CertifyNVCounter: %v", err)
+	}
+
+	wrongNVName := bytes.Repeat([]byte{0xAB}, 34) // wrong name
+	_, err = VerifyNVCounter(&cert, aikPub, nonce, wrongNVName)
+	if err == nil {
+		t.Fatal("expected NV name mismatch error, got nil")
 	}
 }

--- a/tpmea_test.go
+++ b/tpmea_test.go
@@ -20,13 +20,16 @@ import (
 )
 
 const (
-	RESETABLE_PCR_INDEX     = 16
-	NV_INDEX                = 0x1500016
-	NV_COUNTER_INDEX        = 0x1500017
-	NV_COUNTER_INDEX_AUTH   = 0x1500019 // counter with index-auth mode
-	NV_WRONG_TYPE_HANDLE    = 0x1500018
+	RESETABLE_PCR_INDEX   = 16
+	NV_INDEX              = 0x1500016
+	NV_COUNTER_INDEX      = 0x1500017
+	NV_COUNTER_INDEX_AUTH = 0x1500019 // counter with index-auth mode
+	NV_WRONG_TYPE_HANDLE  = 0x1500018
 	// AIK_HANDLE is the RSA restricted signing key provisioned by runtests.sh
 	AIK_HANDLE = uint32(0x81000003)
+	// EK_HANDLE is the RSA endorsement key (restricted|decrypt) provisioned
+	// by runtests.sh; used as the salt key for encrypted sessions.
+	EK_HANDLE = uint32(0x81000001)
 )
 
 var PCR_INDEXES = []int{0, 1, 2, 3, 4, 5}
@@ -1099,5 +1102,309 @@ func TestVerifyNVCounterWrongNVName(t *testing.T) {
 	_, err = VerifyNVCounter(&cert, aikPub, nonce, wrongNVName)
 	if err == nil {
 		t.Fatal("expected NV name mismatch error, got nil")
+	}
+}
+
+// The tests below exercise every combination of encrypted and plain
+// SealSecret / UnsealSecret, with both RSA and ECC signing keys.
+// The salt key for encrypted sessions is the EK at EK_HANDLE.
+//
+// sealFunc / unsealFunc abstract the seal/unseal call so the same test
+// body can be reused across encryption modes.
+type sealFunc func(handle uint32, authDigest []byte, secret []byte) error
+type unsealFunc func(handle uint32, publicKey crypto.PublicKey, sp SignedPolicy, sel PCRSelection, rbp RBP) ([]byte, error)
+
+func plainSeal(handle uint32, authDigest []byte, secret []byte) error {
+	return SealSecret(handle, authDigest, secret)
+}
+
+func encryptedSeal(handle uint32, authDigest []byte, secret []byte) error {
+	return SealSecretEncrypted(handle, authDigest, secret, EK_HANDLE)
+}
+
+func plainUnseal(handle uint32, publicKey crypto.PublicKey, sp SignedPolicy, sel PCRSelection, rbp RBP) ([]byte, error) {
+	return UnsealSecret(handle, publicKey, sp, sel, rbp)
+}
+
+func encryptedUnseal(handle uint32, publicKey crypto.PublicKey, sp SignedPolicy, sel PCRSelection, rbp RBP) ([]byte, error) {
+	return UnsealSecretEncrypted(handle, publicKey, sp, sel, rbp, EK_HANDLE)
+}
+
+var encryptionModes = []struct {
+	name   string
+	seal   sealFunc
+	unseal unsealFunc
+}{
+	{"plain_seal/plain_unseal", plainSeal, plainUnseal},
+	{"encrypted_seal/encrypted_unseal", encryptedSeal, encryptedUnseal},
+	{"encrypted_seal/plain_unseal", encryptedSeal, plainUnseal},
+	{"plain_seal/encrypted_unseal", plainSeal, encryptedUnseal},
+}
+
+// TestEncryptedSimpleSealUnsealRSA runs the simple seal/unseal flow with all
+// encryption combinations using an RSA signing key.
+func TestEncryptedSimpleSealUnsealRSA(t *testing.T) {
+	key, _ := genTpmKeyPairRSA()
+	for _, m := range encryptionModes {
+		t.Run(m.name, func(t *testing.T) {
+			testEncryptedSimpleSealUnseal(t, key, &key.PublicKey, m.seal, m.unseal)
+		})
+	}
+}
+
+// TestEncryptedSimpleSealUnsealECC runs the simple seal/unseal flow with all
+// encryption combinations using an ECC signing key.
+func TestEncryptedSimpleSealUnsealECC(t *testing.T) {
+	key, _ := genTpmKeyPairECC()
+	for _, m := range encryptionModes {
+		t.Run(m.name, func(t *testing.T) {
+			testEncryptedSimpleSealUnseal(t, key, &key.PublicKey, m.seal, m.unseal)
+		})
+	}
+}
+
+func testEncryptedSimpleSealUnseal(t *testing.T, privateKey crypto.PrivateKey, publicKey crypto.PublicKey, seal sealFunc, unseal unsealFunc) {
+	authorizationDigest, err := GenerateAuthDigest(publicKey)
+	if err != nil {
+		t.Fatalf("GenerateAuthDigest: %v", err)
+	}
+
+	for _, index := range PCR_INDEXES {
+		if err := extendPCR(index, AlgoSHA256, []byte("ENC_SEAL_EXTEND")); err != nil {
+			t.Fatalf("extendPCR: %v", err)
+		}
+	}
+
+	pcrs, err := readPCRs(PCR_INDEXES, AlgoSHA256)
+	if err != nil {
+		t.Fatalf("readPCRs: %v", err)
+	}
+
+	sealingPcrs := make(PCRS, 0)
+	for _, index := range PCR_INDEXES {
+		sealingPcrs = append(sealingPcrs, PCR{Index: pcrs.Pcrs[index].Index, Digest: pcrs.Pcrs[index].Digest})
+	}
+	pcrsList := PCRList{Algo: AlgoSHA256, Pcrs: sealingPcrs}
+
+	sp, err := GenerateSignedPolicy(privateKey, pcrsList, RBP{})
+	if err != nil {
+		t.Fatalf("GenerateSignedPolicy: %v", err)
+	}
+
+	writtenSecret := []byte("ENCRYPTED_SESSION_SECRET")
+	if err := seal(NV_INDEX, authorizationDigest, writtenSecret); err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	sel := PCRSelection{Algo: AlgoSHA256, Indexes: PCR_INDEXES}
+	readSecret, err := unseal(NV_INDEX, publicKey, sp, sel, RBP{})
+	if err != nil {
+		t.Fatalf("Unseal: %v", err)
+	}
+
+	if !bytes.Equal(writtenSecret, readSecret) {
+		t.Fatalf("secret mismatch: wrote %q, read %q", writtenSecret, readSecret)
+	}
+}
+
+// TestEncryptedMutablePolicySealUnsealRSA runs the mutable policy flow (seal,
+// unseal, PCR change, re-sign, unseal again) with all encryption combos.
+func TestEncryptedMutablePolicySealUnsealRSA(t *testing.T) {
+	for _, m := range encryptionModes {
+		t.Run(m.name, func(t *testing.T) {
+			key, _ := genTpmKeyPairRSA()
+			testEncryptedMutablePolicySealUnseal(t, key, &key.PublicKey, m.seal, m.unseal)
+		})
+	}
+}
+
+// TestEncryptedMutablePolicySealUnsealECC runs the mutable policy flow with
+// all encryption combos using ECC.
+func TestEncryptedMutablePolicySealUnsealECC(t *testing.T) {
+	for _, m := range encryptionModes {
+		t.Run(m.name, func(t *testing.T) {
+			key, _ := genTpmKeyPairECC()
+			testEncryptedMutablePolicySealUnseal(t, key, &key.PublicKey, m.seal, m.unseal)
+		})
+	}
+}
+
+func testEncryptedMutablePolicySealUnseal(t *testing.T, privateKey crypto.PrivateKey, publicKey crypto.PublicKey, seal sealFunc, unseal unsealFunc) {
+	authorizationDigest, err := GenerateAuthDigest(publicKey)
+	if err != nil {
+		t.Fatalf("GenerateAuthDigest: %v", err)
+	}
+
+	for _, index := range PCR_INDEXES {
+		if err := extendPCR(index, AlgoSHA256, []byte("ENC_MUTABLE_EXTEND")); err != nil {
+			t.Fatalf("extendPCR: %v", err)
+		}
+	}
+
+	pcrs, err := readPCRs(PCR_INDEXES, AlgoSHA256)
+	if err != nil {
+		t.Fatalf("readPCRs: %v", err)
+	}
+
+	sealingPcrs := make(PCRS, 0)
+	for _, index := range PCR_INDEXES {
+		sealingPcrs = append(sealingPcrs, PCR{Index: pcrs.Pcrs[index].Index, Digest: pcrs.Pcrs[index].Digest})
+	}
+	pcrsList := PCRList{Algo: AlgoSHA256, Pcrs: sealingPcrs}
+
+	sp, err := GenerateSignedPolicy(privateKey, pcrsList, RBP{})
+	if err != nil {
+		t.Fatalf("GenerateSignedPolicy: %v", err)
+	}
+
+	writtenSecret := []byte("ENC_MUTABLE_SECRET")
+	if err := seal(NV_INDEX, authorizationDigest, writtenSecret); err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	sel := PCRSelection{Algo: AlgoSHA256, Indexes: PCR_INDEXES}
+	readSecret, err := unseal(NV_INDEX, publicKey, sp, sel, RBP{})
+	if err != nil {
+		t.Fatalf("Unseal: %v", err)
+	}
+	if !bytes.Equal(writtenSecret, readSecret) {
+		t.Fatalf("secret mismatch: wrote %q, read %q", writtenSecret, readSecret)
+	}
+
+	// extend a PCR to invalidate the current policy
+	pick := PCR_INDEXES[rand.Intn(len(PCR_INDEXES))]
+	if err := extendPCR(pick, AlgoSHA256, []byte("ENC_MUTABLE_EXTEND_2")); err != nil {
+		t.Fatalf("extendPCR: %v", err)
+	}
+
+	// unseal must fail with the old policy
+	_, err = unseal(NV_INDEX, publicKey, sp, sel, RBP{})
+	if err == nil {
+		t.Fatal("expected unseal to fail after PCR change, got nil")
+	}
+	if !strings.Contains(err.Error(), "TPM_RC_VALUE") {
+		t.Fatalf("expected TPM_RC_VALUE error, got %v", err)
+	}
+
+	// re-read PCRs and re-sign
+	pcrs, err = readPCRs(PCR_INDEXES, AlgoSHA256)
+	if err != nil {
+		t.Fatalf("readPCRs: %v", err)
+	}
+	sealingPcrs = make(PCRS, 0)
+	for _, index := range PCR_INDEXES {
+		sealingPcrs = append(sealingPcrs, PCR{Index: pcrs.Pcrs[index].Index, Digest: pcrs.Pcrs[index].Digest})
+	}
+	pcrsList = PCRList{Algo: AlgoSHA256, Pcrs: sealingPcrs}
+
+	sp, err = GenerateSignedPolicy(privateKey, pcrsList, RBP{})
+	if err != nil {
+		t.Fatalf("GenerateSignedPolicy: %v", err)
+	}
+
+	// unseal must succeed with the new policy
+	readSecret, err = unseal(NV_INDEX, publicKey, sp, sel, RBP{})
+	if err != nil {
+		t.Fatalf("Unseal after re-sign: %v", err)
+	}
+	if !bytes.Equal(writtenSecret, readSecret) {
+		t.Fatalf("secret mismatch after re-sign: wrote %q, read %q", writtenSecret, readSecret)
+	}
+}
+
+// TestEncryptedSealWithRollbackProtectionRSA exercises encrypted seal/unseal
+// together with rollback protection counters.
+func TestEncryptedSealWithRollbackProtectionRSA(t *testing.T) {
+	for _, m := range encryptionModes {
+		t.Run(m.name, func(t *testing.T) {
+			key, _ := genTpmKeyPairRSA()
+			testEncryptedSealWithRollbackProtection(t, key, &key.PublicKey, m.seal, m.unseal)
+		})
+	}
+}
+
+func TestEncryptedSealWithRollbackProtectionECC(t *testing.T) {
+	for _, m := range encryptionModes {
+		t.Run(m.name, func(t *testing.T) {
+			key, _ := genTpmKeyPairECC()
+			testEncryptedSealWithRollbackProtection(t, key, &key.PublicKey, m.seal, m.unseal)
+		})
+	}
+}
+
+func testEncryptedSealWithRollbackProtection(t *testing.T, privateKey crypto.PrivateKey, publicKey crypto.PublicKey, seal sealFunc, unseal unsealFunc) {
+	authorizationDigest, err := GenerateAuthDigest(publicKey)
+	if err != nil {
+		t.Fatalf("GenerateAuthDigest: %v", err)
+	}
+
+	for _, index := range PCR_INDEXES {
+		if err := extendPCR(index, AlgoSHA256, []byte("ENC_RBP_EXTEND")); err != nil {
+			t.Fatalf("extendPCR: %v", err)
+		}
+	}
+
+	rbp := RBP{Counter: NV_COUNTER_INDEX}
+	rbpCounter, err := DefineMonotonicCounter(rbp)
+	if err != nil {
+		t.Fatalf("DefineMonotonicCounter: %v", err)
+	}
+	rbp.Check = rbpCounter
+
+	pcrs, err := readPCRs(PCR_INDEXES, AlgoSHA256)
+	if err != nil {
+		t.Fatalf("readPCRs: %v", err)
+	}
+
+	sealingPcrs := make(PCRS, 0)
+	for _, index := range PCR_INDEXES {
+		sealingPcrs = append(sealingPcrs, PCR{Index: pcrs.Pcrs[index].Index, Digest: pcrs.Pcrs[index].Digest})
+	}
+	pcrsList := PCRList{Algo: AlgoSHA256, Pcrs: sealingPcrs}
+
+	sp, err := GenerateSignedPolicy(privateKey, pcrsList, rbp)
+	if err != nil {
+		t.Fatalf("GenerateSignedPolicy: %v", err)
+	}
+
+	writtenSecret := []byte("ENC_RBP_SECRET")
+	if err := seal(NV_INDEX, authorizationDigest, writtenSecret); err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	sel := PCRSelection{Algo: AlgoSHA256, Indexes: PCR_INDEXES}
+	readSecret, err := unseal(NV_INDEX, publicKey, sp, sel, rbp)
+	if err != nil {
+		t.Fatalf("Unseal: %v", err)
+	}
+	if !bytes.Equal(writtenSecret, readSecret) {
+		t.Fatalf("secret mismatch: wrote %q, read %q", writtenSecret, readSecret)
+	}
+
+	// increment counter to invalidate the old policy
+	rbpCounter, err = IncreaseMonotonicCounter(rbp)
+	if err != nil {
+		t.Fatalf("IncreaseMonotonicCounter: %v", err)
+	}
+
+	// old policy should fail
+	_, err = unseal(NV_INDEX, publicKey, sp, sel, rbp)
+	if err == nil {
+		t.Fatal("expected unseal to fail after counter increment, got nil")
+	}
+
+	// re-sign with new counter value
+	rbp.Check = rbpCounter
+	sp, err = GenerateSignedPolicy(privateKey, pcrsList, rbp)
+	if err != nil {
+		t.Fatalf("GenerateSignedPolicy: %v", err)
+	}
+
+	readSecret, err = unseal(NV_INDEX, publicKey, sp, sel, rbp)
+	if err != nil {
+		t.Fatalf("Unseal after re-sign: %v", err)
+	}
+	if !bytes.Equal(writtenSecret, readSecret) {
+		t.Fatalf("secret mismatch after re-sign: wrote %q, read %q", writtenSecret, readSecret)
 	}
 }

--- a/tpmea_test.go
+++ b/tpmea_test.go
@@ -20,14 +20,27 @@ import (
 )
 
 const (
-	RESETABLE_PCR_INDEX = 16
-	NV_INDEX            = 0x1500016
-	NV_COUNTER_INDEX    = 0x1500017
+	RESETABLE_PCR_INDEX     = 16
+	NV_INDEX                = 0x1500016
+	NV_COUNTER_INDEX        = 0x1500017
+	NV_COUNTER_INDEX_AUTH   = 0x1500019 // counter with index-auth mode
+	NV_WRONG_TYPE_HANDLE    = 0x1500018
 	// AIK_HANDLE is the RSA restricted signing key provisioned by runtests.sh
 	AIK_HANDLE = uint32(0x81000003)
 )
 
 var PCR_INDEXES = []int{0, 1, 2, 3, 4, 5}
+
+// counterAuthModes returns the two counter auth configurations to test.
+// Owner mode uses the existing NV_COUNTER_INDEX, index-auth mode uses a
+// separate handle so the different NV attributes don't collide.
+var counterAuthModes = []struct {
+	name string
+	rbp  func() RBP
+}{
+	{"owner", func() RBP { return RBP{Counter: NV_COUNTER_INDEX, AuthMode: CounterAuthOwner} }},
+	{"index", func() RBP { return RBP{Counter: NV_COUNTER_INDEX_AUTH, AuthMode: CounterAuthIndex, Password: []byte{}} }},
+}
 
 func TestMain(m *testing.M) {
 	if socketPath := os.Getenv("SWTPM_SERVER_PATH"); socketPath != "" {
@@ -193,19 +206,26 @@ func TestPCRExtend(t *testing.T) {
 
 // TestMonotonicCounter verifies that a monotonic counter can be defined and
 // incremented, and that its value goes up by exactly one on each increment.
+// It runs in both owner-auth and index-auth modes.
 func TestMonotonicCounter(t *testing.T) {
-	initCounter, err := DefineMonotonicCounter(NV_COUNTER_INDEX)
-	if err != nil {
-		t.Fatalf("Expected no error, got  \"%v\"", err)
-	}
+	for _, m := range counterAuthModes {
+		t.Run(m.name, func(t *testing.T) {
+			rbp := m.rbp()
+			initCounter, err := DefineMonotonicCounter(rbp)
+			if err != nil {
+				t.Fatalf("Expected no error, got  \"%v\"", err)
+			}
 
-	updatedCounter, err := IncreaseMonotonicCounter(NV_COUNTER_INDEX)
-	if err != nil {
-		t.Fatalf("Expected no error, got  \"%v\"", err)
-	}
+			rbp.Check = initCounter
+			updatedCounter, err := IncreaseMonotonicCounter(rbp)
+			if err != nil {
+				t.Fatalf("Expected no error, got  \"%v\"", err)
+			}
 
-	if updatedCounter != (initCounter + 1) {
-		t.Fatalf("Expected counter value of %d, got %d", (initCounter + 1), updatedCounter)
+			if updatedCounter != (initCounter + 1) {
+				t.Fatalf("Expected counter value of %d, got %d", (initCounter + 1), updatedCounter)
+			}
+		})
 	}
 }
 
@@ -377,17 +397,26 @@ func testMutablePolicySealUnseal(t *testing.T, privateKey crypto.PrivateKey, pub
 // TestMutablePolicySealUnsealWithRollbackProtection* verify that rollback
 // protection works: an old policy is rejected once the counter is incremented,
 // and a new policy bound to the updated counter value restores access.
+// Each key type is tested with both owner-auth and index-auth counter modes.
 func TestMutablePolicySealUnsealWithRollbackProtectionRSA(t *testing.T) {
-	key, _ := genTpmKeyPairRSA()
-	testMutablePolicySealUnsealWithRollbackProtection(t, key, &key.PublicKey)
+	for _, m := range counterAuthModes {
+		t.Run(m.name, func(t *testing.T) {
+			key, _ := genTpmKeyPairRSA()
+			testMutablePolicySealUnsealWithRollbackProtection(t, key, &key.PublicKey, m.rbp())
+		})
+	}
 }
 
 func TestMutablePolicySealUnsealWithRollbackProtectionECC(t *testing.T) {
-	key, _ := genTpmKeyPairECC()
-	testMutablePolicySealUnsealWithRollbackProtection(t, key, &key.PublicKey)
+	for _, m := range counterAuthModes {
+		t.Run(m.name, func(t *testing.T) {
+			key, _ := genTpmKeyPairECC()
+			testMutablePolicySealUnsealWithRollbackProtection(t, key, &key.PublicKey, m.rbp())
+		})
+	}
 }
 
-func testMutablePolicySealUnsealWithRollbackProtection(t *testing.T, privateKey crypto.PrivateKey, publicKey crypto.PublicKey) {
+func testMutablePolicySealUnsealWithRollbackProtection(t *testing.T, privateKey crypto.PrivateKey, publicKey crypto.PublicKey, rbp RBP) {
 	authorizationDigest, err := GenerateAuthDigest(publicKey)
 	if err != nil {
 		t.Fatalf("Expected no error, got  \"%v\"", err)
@@ -402,11 +431,11 @@ func testMutablePolicySealUnsealWithRollbackProtection(t *testing.T, privateKey 
 		}
 	}
 
-	rbpCounter, err := DefineMonotonicCounter(NV_COUNTER_INDEX)
+	rbpCounter, err := DefineMonotonicCounter(rbp)
 	if err != nil {
 		t.Fatalf("Expected no error, got  \"%v\"", err)
 	}
-	rbp := RBP{Counter: NV_COUNTER_INDEX, Check: rbpCounter}
+	rbp.Check = rbpCounter
 
 	pcrs, err := readPCRs(PCR_INDEXES, AlgoSHA256)
 	if err != nil {
@@ -483,7 +512,7 @@ func testMutablePolicySealUnsealWithRollbackProtection(t *testing.T, privateKey 
 	}
 
 	// now lets increase the counter
-	rbpCounter, err = IncreaseMonotonicCounter(NV_COUNTER_INDEX)
+	rbpCounter, err = IncreaseMonotonicCounter(rbp)
 	if err != nil {
 		t.Fatalf("Expected no error, got  \"%v\"", err)
 	}
@@ -733,7 +762,8 @@ func testUnsealSecretTamperedSignature(t *testing.T, privateKey crypto.PrivateKe
 // TestSealSecretRejectsCounterHandle verifies that SealSecret refuses to
 // overwrite a monotonic counter NV index.
 func TestSealSecretRejectsCounterHandle(t *testing.T) {
-	_, err := DefineMonotonicCounter(NV_COUNTER_INDEX)
+	rbp := RBP{Counter: NV_COUNTER_INDEX}
+	_, err := DefineMonotonicCounter(rbp)
 	if err != nil {
 		t.Fatalf("Expected no error, got  \"%v\"", err)
 	}
@@ -748,26 +778,29 @@ func TestSealSecretRejectsCounterHandle(t *testing.T) {
 // DefineMonotonicCounter twice on the same handle succeeds and returns the
 // same value both times (no spurious increment on the second call).
 func TestDefineMonotonicCounterIdempotent(t *testing.T) {
-	counter1, err := DefineMonotonicCounter(NV_COUNTER_INDEX)
-	if err != nil {
-		t.Fatalf("Expected no error, got  \"%v\"", err)
-	}
+	for _, m := range counterAuthModes {
+		t.Run(m.name, func(t *testing.T) {
+			rbp := m.rbp()
+			counter1, err := DefineMonotonicCounter(rbp)
+			if err != nil {
+				t.Fatalf("Expected no error, got  \"%v\"", err)
+			}
 
-	counter2, err := DefineMonotonicCounter(NV_COUNTER_INDEX)
-	if err != nil {
-		t.Fatalf("Expected no error on second call, got  \"%v\"", err)
-	}
+			counter2, err := DefineMonotonicCounter(rbp)
+			if err != nil {
+				t.Fatalf("Expected no error on second call, got  \"%v\"", err)
+			}
 
-	if counter1 != counter2 {
-		t.Fatalf("Expected same counter value on second call, got %d != %d", counter1, counter2)
+			if counter1 != counter2 {
+				t.Fatalf("Expected same counter value on second call, got %d != %d", counter1, counter2)
+			}
+		})
 	}
 }
 
 // TestDefineMonotonicCounterWrongNVType verifies that DefineMonotonicCounter
 // refuses to use an existing NV index whose type is not a counter.
 func TestDefineMonotonicCounterWrongNVType(t *testing.T) {
-	const wrongTypeHandle = uint32(0x1500018)
-
 	key, _ := genTpmKeyPairECC()
 	authorizationDigest, err := GenerateAuthDigest(&key.PublicKey)
 	if err != nil {
@@ -775,12 +808,12 @@ func TestDefineMonotonicCounterWrongNVType(t *testing.T) {
 	}
 
 	// plant an ordinary NV index at the handle.
-	err = SealSecret(wrongTypeHandle, authorizationDigest, []byte("dummy"))
+	err = SealSecret(NV_WRONG_TYPE_HANDLE, authorizationDigest, []byte("dummy"))
 	if err != nil {
 		t.Fatalf("Expected no error from SealSecret, got  \"%v\"", err)
 	}
 
-	_, err = DefineMonotonicCounter(wrongTypeHandle)
+	_, err = DefineMonotonicCounter(RBP{Counter: NV_WRONG_TYPE_HANDLE})
 	if err == nil {
 		t.Fatalf("Expected error when defining counter on ordinary NV handle, got nil")
 	}
@@ -833,7 +866,7 @@ func readAIKPublicKey(t *testing.T) crypto.PublicKey {
 func TestCertifyNVCounter(t *testing.T) {
 	aikPub := readAIKPublicKey(t)
 
-	counterVal, err := DefineMonotonicCounter(NV_COUNTER_INDEX)
+	counterVal, err := DefineMonotonicCounter(RBP{Counter: NV_COUNTER_INDEX})
 	if err != nil {
 		t.Fatalf("DefineMonotonicCounter: %v", err)
 	}
@@ -868,12 +901,12 @@ func TestCertifyNVCounter(t *testing.T) {
 func TestVerifyNVCounterIncrementedValue(t *testing.T) {
 	aikPub := readAIKPublicKey(t)
 
-	_, err := DefineMonotonicCounter(NV_COUNTER_INDEX)
+	_, err := DefineMonotonicCounter(RBP{Counter: NV_COUNTER_INDEX})
 	if err != nil {
 		t.Fatalf("DefineMonotonicCounter: %v", err)
 	}
 
-	incremented, err := IncreaseMonotonicCounter(NV_COUNTER_INDEX)
+	incremented, err := IncreaseMonotonicCounter(RBP{Counter: NV_COUNTER_INDEX})
 	if err != nil {
 		t.Fatalf("IncreaseMonotonicCounter: %v", err)
 	}
@@ -907,7 +940,7 @@ func TestVerifyNVCounterIncrementedValue(t *testing.T) {
 func TestVerifyNVCounterNonceMismatch(t *testing.T) {
 	aikPub := readAIKPublicKey(t)
 
-	_, err := DefineMonotonicCounter(NV_COUNTER_INDEX)
+	_, err := DefineMonotonicCounter(RBP{Counter: NV_COUNTER_INDEX})
 	if err != nil {
 		t.Fatalf("DefineMonotonicCounter: %v", err)
 	}
@@ -936,7 +969,7 @@ func TestVerifyNVCounterNonceMismatch(t *testing.T) {
 // TestVerifyNVCounterWrongKey verifies that a cert signed by the AIK cannot
 // be verified with a different RSA key.
 func TestVerifyNVCounterWrongKey(t *testing.T) {
-	_, err := DefineMonotonicCounter(NV_COUNTER_INDEX)
+	_, err := DefineMonotonicCounter(RBP{Counter: NV_COUNTER_INDEX})
 	if err != nil {
 		t.Fatalf("DefineMonotonicCounter: %v", err)
 	}
@@ -963,7 +996,7 @@ func TestVerifyNVCounterWrongKey(t *testing.T) {
 func TestVerifyNVCounterTamperedSignature(t *testing.T) {
 	aikPub := readAIKPublicKey(t)
 
-	_, err := DefineMonotonicCounter(NV_COUNTER_INDEX)
+	_, err := DefineMonotonicCounter(RBP{Counter: NV_COUNTER_INDEX})
 	if err != nil {
 		t.Fatalf("DefineMonotonicCounter: %v", err)
 	}
@@ -1047,7 +1080,7 @@ func TestVerifyNVCounterECCMissingComponents(t *testing.T) {
 func TestVerifyNVCounterWrongNVName(t *testing.T) {
 	aikPub := readAIKPublicKey(t)
 
-	_, err := DefineMonotonicCounter(NV_COUNTER_INDEX)
+	_, err := DefineMonotonicCounter(RBP{Counter: NV_COUNTER_INDEX})
 	if err != nil {
 		t.Fatalf("DefineMonotonicCounter: %v", err)
 	}


### PR DESCRIPTION
This PR fixes several bugs found by auditing the code against the TPM 2.0 spec, and adds new encrypted seal/unseal APIs.

Bug fixes:

- SealSecret now validates the secret size against the real TPM NV buffer limit instead of silently truncating. 
- NV counter attribute checks use strict equality so we don't accidentally accept an index with extra flags that would change its TPM Name and break policy digests. 
- VerifyNVCounter now checks the NV index Name from the attestation to prevent index substitution attacks, and returns an error on nil input instead of silently returning zero. 
- The signature hash algorithm is no longer hardcoded to SHA-256 in VerifyNVCounter, it reads the algorithm from the attestation so it works correctly with any hash the AIK uses.

New features:

- PolicyNV counter authorization is now configurable. Previously it always went through the Owner hierarchy, which requires knowing the TPM owner password and breaks in production where that password is locked down. Callers can now choose between owner auth (the default, backward compatible) and index-based auth where the counter uses its own password. All rollback protection tests run in both modes.

- SealSecretEncrypted and UnsealSecretEncrypted use salted HMAC sessions with AES-128-CFB parameter encryption to protect secrets on the CPU-TPM bus. The caller provides a salt key handle (typically the EK) and the library handles session setup. Tests cover all four combinations of plain and encrypted seal/unseal.